### PR TITLE
Add Windows support to kgrep Homebrew formula

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     
     steps:
@@ -20,11 +20,20 @@ jobs:
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
     
-    - name: Tap local repository
+    - name: Tap local repository (Unix)
+      if: runner.os != 'Windows'
       run: |
         # Create a temporary tap name and tap the local directory
         mkdir -p $(brew --repo)/Library/Taps/test
         ln -sf $PWD $(brew --repo)/Library/Taps/test/homebrew-kgrep
+    
+    - name: Tap local repository (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        # Create a temporary tap name and tap the local directory
+        mkdir -p "$(brew --repo)/Library/Taps/test"
+        New-Item -ItemType Junction -Path "$(brew --repo)/Library/Taps/test/homebrew-kgrep" -Target $PWD
+      shell: pwsh
     
     - name: Test formula syntax
       run: brew audit --strict test/kgrep/kgrep
@@ -34,7 +43,8 @@ jobs:
         # Test that the formula can be installed
         brew install test/kgrep/kgrep
     
-    - name: Test kgrep functionality
+    - name: Test kgrep functionality (Unix)
+      if: runner.os != 'Windows'
       run: |
         # Verify kgrep binary exists and is executable
         which kgrep
@@ -43,4 +53,17 @@ jobs:
         kgrep version
         kgrep --help
         
-        echo "All kgrep functionality tests passed" 
+        echo "All kgrep functionality tests passed"
+    
+    - name: Test kgrep functionality (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        # Verify kgrep binary exists and is executable
+        where kgrep
+        
+        # Test basic kgrep commands
+        kgrep version
+        kgrep --help
+        
+        Write-Host "All kgrep functionality tests passed"
+      shell: pwsh 

--- a/kgrep.rb
+++ b/kgrep.rb
@@ -27,6 +27,18 @@ class Kgrep < Formula
     end
   end
 
+  on_windows do
+    on_intel do
+      url "https://github.com/kgrep-org/kgrep/releases/download/v0.4.2/kgrep-windows-amd64.zip"
+      sha256 "d7d8fcb080098534bbedcc0476539ce77ce68a820acc5d925508156958c4f63f"
+    end
+
+    on_arm do
+      url "https://github.com/kgrep-org/kgrep/releases/download/v0.4.2/kgrep-windows-arm64.zip"
+      sha256 "f9ea6fa68e12cf37c7bf6f88a0e2a2da0422a4859f0b3c0808622412144bd57a"
+    end
+  end
+
   depends_on "kubectl"
 
   def install


### PR DESCRIPTION
- Add Windows Intel (AMD64) and ARM64 binary support with .zip format
- Include actual SHA256 hashes for Windows binaries
- Update CI workflow to test on windows-latest
- Add cross-platform compatibility for tap setup and functionality tests
- Support PowerShell commands for Windows CI steps